### PR TITLE
Draft: Initial implementation of command to swap wayland session

### DIFF
--- a/wayland_editor.sh
+++ b/wayland_editor.sh
@@ -1,0 +1,24 @@
+function no_wayland() {
+    sed -i 's/#WaylandEnable=false/WaylandEnable=false/g' $1
+}
+
+function wayland() {
+    sed -i 's/WaylandEnable=false/#WaylandEnable=false/g' $1
+}
+
+wayland=$1
+
+function find_gdm_file() {
+    if [[ -z "$TEST_FILE" ]]; then
+        gdm_custom_conf="/etc/gdm/custom.conf"
+    else
+        gdm_custom_conf="$TEST_FILE"
+    fi
+    [ -f "$gdm_custom_conf" ] && echo "$gdm_custom_conf" || exit 0 # no autologin, user makes choice
+}
+
+if [[ "$wayland" == "yes" ]]; then
+    wayland "$(find_gdm_file)"
+else
+    no_wayland "$(find_gdm_file)"
+fi


### PR DESCRIPTION
Some games run better on wayland and especially when remote playing. For instance Fifa 22 has flickering cinematics on Xorg. 
Steam beta on Pipewire seemed to have solved a lot of issues, however it is broken again after some recent changes ([from what I gather](https://github.com/ValveSoftware/steam-for-linux/issues/6148)).
Although last time I had a full Xorg auto-login, it would be useful to have the wayland option while not at home. Even if things start working again, I need to take into consideration that an update may break it which will lock me outside of my system until I'm back home.

/etc/gdm/custom.conf needs to be edited to force wayland or Xorg on desktop auto-login. However, the following issues need to be solved:

- [ ]  Editing the file needs root access, while the Alexa process runs on desktop permissions, it might not have access to edit the file.

One way to solve this is to have another process running on elevated privileges for the sole purpose of switching from wayland to xorg. Might need to dig further if this would be possible with current service privileges. 
